### PR TITLE
Allow connection test to be started automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ the root of your deployment. For example, if Guacamole is deployed to
 
 Visiting the connection testing page does not require authentication. Any users
 visiting the URL will immediately see a welcome screen instructing them to
-click the "Start Test" button to start the test. Once the test has started,
-a progress bar will be displayed showing the current state of the test. The
-test should take less than one second per server on average.
+click the "Start Test" button to start the test. Alternatively, to start the
+test automatically without prompting, include the query parameter `auto=1`
+within the URL. Once the test has started, a progress bar will be displayed
+showing the current state of the test. The test should take less than one
+second per server on average.
 
 Once the test has completed, a table of results will be displayed listing all
 available servers in order of responsiveness. Connection quality is ranked and

--- a/src/main/resources/controllers/connectionTesterController.js
+++ b/src/main/resources/controllers/connectionTesterController.js
@@ -37,6 +37,16 @@ angular.module('guacConntest').controller('connectionTesterController', ['$scope
     var desiredConcurrency = $routeParams.n && parseInt($routeParams.n);
 
     /**
+     * Whether the connection test should be started automatically, once the
+     * interface and associated resources have finished loading, as specified
+     * by a non-zero value for the "auto" parameter in the URL. By default, the
+     * user will be prompted to start the test.
+     *
+     * @type Boolean
+     */
+    $scope.startAutomatically = !!$routeParams.auto;
+
+    /**
      * The current status of the connection test.
      *
      * @type Status
@@ -89,6 +99,19 @@ angular.module('guacConntest').controller('connectionTesterController', ['$scope
         connectionTestingService.startTest(desiredConcurrency);
     };
 
+    /**
+     * Returns whether the prompt for starting the connection test should be
+     * visible to the user. In general, the prompt should only be visible if
+     * the test has not started and will not be starting automatically.
+     *
+     * @returns {Boolean}
+     *     true if the connection test prompt should be displayed, false
+     *     otherwise.
+     */
+    $scope.isPromptVisible = function isPromptVisible() {
+        return !($scope.status.started || $scope.startAutomatically);
+    };
+
     // Display results when ready
     connectionTestingService.getResults().then(function testComplete(results) {
         $scope.results = results;
@@ -97,6 +120,12 @@ angular.module('guacConntest').controller('connectionTesterController', ['$scope
     // Update status as test continues
     ['finally'](null, function testProgress(status) {
         $scope.status = status;
+    });
+
+    // Automatically start the test if configured to do so
+    $scope.$on('$viewContentLoaded', function interfaceLoaded() {
+        if ($scope.startAutomatically)
+            $scope.startTest();
     });
 
 }]);

--- a/src/main/resources/templates/connectionTester.html
+++ b/src/main/resources/templates/connectionTester.html
@@ -67,7 +67,7 @@
         <div class="connection-tester-progress-inner">
 
             <!-- Welcome/start prompt -->
-            <div class="connection-tester-welcome" ng-hide="status.started">
+            <div class="connection-tester-welcome" ng-hide="!isPromptVisible()">
                 <h1>{{'CONNTEST.NAME' | translate}}</h1>
                 <p>{{'CONNTEST.HELP_TOOL_DESCRIPTION' | translate}}</p>
                 <p>{{'CONNTEST.HELP_STARTING_TEST' | translate}}</p>


### PR DESCRIPTION
This change removes the need for the user to manually click the "Start Test" button, allowing "auto=1" to be specified within the URL instead.