### PR TITLE
Add target="_self" to server links to force a reload.

### DIFF
--- a/src/main/resources/templates/connectionTester.html
+++ b/src/main/resources/templates/connectionTester.html
@@ -32,7 +32,8 @@
                              alt="{{result.server.country}}"/>
                         {{result.name}}
                     </td>
-                    <td class="server-url"><a ng-href="{{result.server.url}}">{{result.server.url}}</a></td>
+                    <td class="server-url"><a ng-href="{{result.server.url}}"
+                                              target="_self">{{result.server.url}}</a></td>
                     <td class="server-result">
 
                         <!-- Final result statistics, available only when result is complete -->


### PR DESCRIPTION
Sadly, AngularJS fails to route properly if navigating via a normal `<a href="...">` link to the main page of the same AngularJS app. Things only work if either (1) the trailing `/#/` is included within the URL or (2) `target="_self"` is included to force a page reload. In the case of guacamole-connection-tester, this means that any links pointing to the current server within the results fail mysteriously, taking the user to a blank page.

This change adds `target="_self"` to all server links within the results, forcing a reload.